### PR TITLE
Fix "windows users, comment this code!"

### DIFF
--- a/antiplatformer/antiplatformer.csproj
+++ b/antiplatformer/antiplatformer.csproj
@@ -10,6 +10,9 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <ReleaseVersion>A-0.2.1</ReleaseVersion>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+   <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/antiplatformer/main.cs
+++ b/antiplatformer/main.cs
@@ -4,9 +4,10 @@
     {
         public static void Main(string[] args)
         {
-            //---LINUX ONLY---
-            //it fixes random linux crashes, windows users comment out these lines please!
+            #if !WINDOWS
             XInitThreads();
+            #endif
+                
             Game game = new Game(args);
 
             game.init();
@@ -19,9 +20,9 @@
             game.shutdown();
         }
 
-        //---LINUX ONLY---
-        //it fixes random linux crashes, windows users comment out these lines please!
+        #if !WINDOWS
         [System.Runtime.InteropServices.DllImport("X11")]
         extern public static int XInitThreads();
+        #endif
     }
 }


### PR DESCRIPTION
I didn't look through the whole code yet, but usually, if you want OS-specific code, you can use preprocessor macros. Like in this PR, there is the new WINDOWS macro and you can use `!WINDOWS` to say if the system is Linux (yes I know you can make a LINUX macro but I'm lazy 😛).

Also, the naming convention is not really the official C# one, but that's not the point of the PR..